### PR TITLE
Typo in superfluous_disable_command

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,7 +18,7 @@ disabled_rules:
 - function_parameter_count
 - identifier_name
 - redundant_string_enum_value
-- superfluous_disable_comman
+- superfluous_disable_command
 - unused_closure_parameter
 - trailing_comma
 


### PR DESCRIPTION
Matching [SwiftLint’s documentation](https://github.com/realm/SwiftLint/blob/cc57ed3d69b99c23126176f4f241d9de3dcaa877/Rules.md#L19293-L19299).